### PR TITLE
Added DYLIB Load Commands...

### DIFF
--- a/include/macho/macho-command.h
+++ b/include/macho/macho-command.h
@@ -266,6 +266,64 @@ typedef struct mach_dylinker_command_t {
 } mach_dylinker_command_t; 
 
 
+/**
+ * 	Dynamicly linked Shared Library command.
+ * 
+ * 	This identifies any dynamically shared linked libraries that an
+ * 	executable requires.
+ * 
+ * 	The 'dylib' struct contains the lib properties.
+ * 
+ * 	The 'dylib_command' is the load command structure.
+ * 
+ * 	The dylib name string is stored just after the load command structure.
+ * 	The offset prop is from the start of the load command structure, so
+ * 	the size of the string is:
+ * 		s = cmdsize - (sizeof(uint32_t) * 4);
+ * 
+ */
+
+
+/*
+ * A variable length string in a load command is represented by an lc_str
+ * union.  The strings are stored just after the load command structure and
+ * the offset is from the start of the load command structure.  The size
+ * of the string is reflected in the cmdsize field of the load command.
+ * Once again any padded bytes to bring the cmdsize field to a multiple
+ * of 4 bytes must be zero.
+ */
+typedef struct dylib_vers_t {
+	uint32_t			a;			/* XXXX.00.00 */
+	uint32_t			b;			/* 0000.XX.00 */
+	uint32_t			c;			/* 0000.00.XX */
+} dylib_vers_t;
+
+struct dylib {
+	uint32_t		offset;		/* Offset of the library name in the string table */
+#ifndef __LP64__
+	char			*ptr;		/* pointer to the string */
+#endif
+	
+	uint32_t		timestamp;				/* lib build time stamp */
+	uint32_t		current_version;		/* lib current version numbre */
+	uint32_t		compatibility_version;	/* lib compatibility vers numb */
+};
+
+#include "strutils.h"
+
+typedef struct mach_dylib_command_t {
+	uint32_t		cmd;		/* LC_ID_DYLIB, LC_LOAD_DYLIB, LC_LOAD_WEAK_DYLIB, LC_REEXPORT_DYLIB */
+	uint32_t		cmdsize;	/* Includes pathname string */
+	struct dylib	dylib;
+} mach_dylib_command_t;
+
+typedef struct mach_dylib_command_info_t {
+	mach_dylib_command_t	*dylib;
+	uint32_t				 type;
+	char					*name;
+} mach_dylib_command_info_t;
+
+
 
 //////////////////////////////////////////////////////////////////////////
 //                       Function Definitions                           //
@@ -318,5 +376,11 @@ mach_symtab_command_t *mach_lc_find_symtab_cmd (macho_t *macho);
  */
 mach_dysymtab_command_t *mach_lc_find_dysymtab_cmd (macho_t *macho);
 
+
+/**
+ * 	LC_ID_DYLIB, LC_LOAD_DYLIB, LC_LOAD_WEAK_DYLIB, LC_REEXPORT_DYLIB
+ */
+char *mach_lc_load_dylib_format_version (uint32_t vers);
+char *mach_lc_dylib_get_type_string (mach_dylib_command_t *dylib);
 
 #endif /* libhelper_macho_command_h */

--- a/include/macho/macho-segment.h
+++ b/include/macho/macho-segment.h
@@ -65,6 +65,7 @@ typedef struct mach_segment_command_64_t {
 
 typedef struct mach_segment_info_t {
     mach_segment_command_64_t   *segcmd;    /* Segment command */
+    uint64_t                    padding;
     GSList                      *sections;  /* List of sections */
 } mach_segment_info_t;
 

--- a/include/macho/macho.h
+++ b/include/macho/macho.h
@@ -47,6 +47,7 @@ typedef struct macho_t {
 	mach_header_t 	*header;
 	GSList			*lcmds;				/* mach_command_info_t */
 	GSList			*scmds;				/* mach_segment_info_t */
+	GSList			*dylibs;			/* mach_dylib_command_info_t */
 	GSList			*symbols;			/* mach_symbol_info_t */
 	GSList			*strings;			/* list of strings, in order. */
 } macho_t;

--- a/src/macho/macho-command.c
+++ b/src/macho/macho-command.c
@@ -547,3 +547,35 @@ mach_dysymtab_command_t *mach_lc_find_dysymtab_cmd (macho_t *macho)
 
     return ret;
 }
+
+
+///////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////
+
+char *mach_lc_load_dylib_format_version (uint32_t vers)
+{
+    char *buf = malloc(10);
+    snprintf (buf, 10, "%d.%d.%d", vers >> 16, (vers >> 8) & 0xf, vers & 0xf);
+    return buf;
+}
+
+char *mach_lc_dylib_get_type_string (mach_dylib_command_t *dylib)
+{
+    switch (dylib->cmd) {
+    case LC_ID_DYLIB:
+        return "LC_ID_DYLIB";
+        break;
+    case LC_LOAD_DYLIB:
+        return "LC_LOAD_DYLIB";
+        break;
+    case LC_LOAD_WEAK_DYLIB:
+        return "LC_LOAD_WEAK_DYLIB";
+        break;
+    case LC_REEXPORT_DYLIB:
+        return "LC_REEXPORT_DYLIB";
+        break;
+    default:
+        return "(null)";
+        break;
+    }
+}

--- a/src/macho/macho-segment.c
+++ b/src/macho/macho-segment.c
@@ -82,6 +82,9 @@ mach_segment_info_t *mach_segment_info_load (file_t *file, off_t offset)
     if (segment->vmaddr < 0xffffff0000000000) {
         uint64_t vmaddr = 0xffffff0000000010 + segment->vmaddr;
         segment->vmaddr = vmaddr;
+        si->padding = 0xffffff0000000000;
+    } else {
+        si->padding = 0x0;
     }
 
     // Calculate the offset and start loading section commands


### PR DESCRIPTION
Added support for the following Load Commands: LC_ID_DYLIB, LC_LOAD_DYLIB,
LC_LOAD_WEAK_DYLIB and LC_REEXPORT_DYLIB.

In doing this, I've made a few changes to other areas. The macho_t struct
now has a dylibs GSList. As there are usually multiple of these DYLIB LC's
in a single Mach-O, like Segments, they require special treatment.

This dylibs GSList contains mach_dylib_command_info_t structs, they hold
the actual mach_dylib_command_t's, but also the calculated name property,
and the original type.

When loading a Mach-O using macho_load (), these Load Commands are added
both to the dylib GSList, and the regular Load Commands list. Because
Segment Commands always come first in a Mach-O it's fine to leave them
seperate, but these commands have no fixed place in the file, so by still
adding their regular command info struct to the lcmds list, we can still
determine where they are meant to be.

Sorry if that didn't make much sense. Please let me know of any issues